### PR TITLE
feat(gqlclient): require passing context

### DIFF
--- a/gqlclient.go
+++ b/gqlclient.go
@@ -3,6 +3,7 @@ package gqlclient
 
 import (
 	"net/http"
+	"time"
 )
 
 // Client is the GraphQL client which is returned by New()
@@ -14,8 +15,10 @@ type Client struct {
 // New creates a graphql http
 func New(url string) *Client {
 	c := &Client{
-		url:  url,
-		http: http.DefaultClient,
+		url: url,
+		http: &http.Client{
+			Timeout: 30 * time.Second,
+		},
 	}
 
 	return c

--- a/gqlclient_test.go
+++ b/gqlclient_test.go
@@ -1,6 +1,7 @@
 package gqlclient
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -17,7 +18,7 @@ func TestNew(t *testing.T) {
 		Name string
 	}
 
-	resp, err := client.Send(&data, `query GetUser { user(id: $id) { id name } }`, map[string]interface{}{
+	resp, err := client.Send(context.Background(), &data, `query GetUser { user(id: $id) { id name } }`, map[string]interface{}{
 		"id": "1",
 	})
 
@@ -39,7 +40,7 @@ func TestClient_WithHTTPClient(t *testing.T) {
 		Name string
 	}
 
-	_, err := client.Send(&data, `query GetUser { user(id: $id) { id name } }`, map[string]interface{}{
+	_, err := client.Send(context.Background(), &data, `query GetUser { user(id: $id) { id name } }`, map[string]interface{}{
 		"id": "1",
 	})
 

--- a/readme.md
+++ b/readme.md
@@ -12,16 +12,17 @@ Reasons to use gqlclient:
 
 - Simple, familiar API
 - Use strong Go types for variables and response data
-- Simple error handling
+- Receive a full GraphQL response with data, errors and extensions
+- Respects `context.Context` cancellations and timeouts
 - Supports GraphQL Errors with Extensions
 
-*Note*: This package already works quite well, but it is under heavy development to work towards a v1.0 release. Before that, the API may have breaking changes even with minor versions. 
+*Note*: This package already works quite well, but it is under heavy development to work towards a v1.0 release. Before that, the API may have breaking changes even with minor versions.
 
 Coming soon:
 
 - Uploads
 - Subscriptions
-- More options (http headers, request context)
+- More options (e.g. http headers)
 
 ## Installation
 
@@ -42,6 +43,7 @@ package main
 
 import (
 	"log"
+	"context"
 	"github.com/steebchen/gqlclient"
 )
 
@@ -68,7 +70,7 @@ func main() {
 		}
 	`
 
-	_, err := client.Send(&data, query, variables{
+	_, err := client.Send(context.Background(), &data, query, variables{
 		ID: "55bfed9275de7b060098b9bc",
 	})
 
@@ -88,7 +90,7 @@ func main() {
 If you don't want to use structs, you use `Raw()` to use maps for both input (variables) and output (response data).
 
 ```go
-resp, err := client.Raw(query, map[string]interface{}{
+resp, err := client.Raw(context.Background(), query, map[string]interface{}{
   "id": "55bfed9275de7b060098b9bc",
 })
 


### PR DESCRIPTION
BREAKING CHANGE: all exposed methods now require a context.Context as
the first parameter to allow request cancelling. Respects the Go
guidelines as described in https://golang.org/pkg/context/.

Also adapt the default http timeout to 30 seconds.

Fix #7 